### PR TITLE
FD Leak check support

### DIFF
--- a/lib/scanny/checks/fd_leak_check.rb
+++ b/lib/scanny/checks/fd_leak_check.rb
@@ -1,0 +1,22 @@
+module Scanny
+  module Checks
+    # Checks for use of "File.open" without block, potential FD leak. Using blocks ensures
+    # auto close.
+    class FDLeakCheck < Check
+      def pattern
+        <<-EOT
+          SendWithArguments<
+            name  = :open,
+            block = nil,
+            receiver = ConstantAccess<name = :File>
+          >
+        EOT
+      end
+
+      def check(node)
+        issue :info,
+          "Using File.open without block might lead to file descriptor leak, unless file is explicitly closed."
+      end
+    end
+  end
+end

--- a/spec/scanny/checks/fd_leak_check_spec.rb
+++ b/spec/scanny/checks/fd_leak_check_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+module Scanny::Checks
+  describe FDLeakCheck do
+    before :each do
+      @runner = Scanny::Runner.new(FDLeakCheck.new)
+      @issue = issue(:info, "Using File.open without block might lead to file descriptor leak, unless file is explicitly closed.")
+    end
+
+    it "reports \"File.open\" without block correctly" do
+      @runner.should check('File.open("foo", "r").read').with_issue(@issue)
+      @runner.should check('File.open("foo", "w") { |f| f.write "hi" }').without_issues
+      @runner.should check('File.open("foo", "w") do |f| f.write "hi" end').without_issues
+    end
+  end
+end


### PR DESCRIPTION
Whenever File.open is used without a block, there's potential to leak
a file descriptor, if the file is not explicitly closed.

This patch adds check for such situation and also a spec test.

Signed-off-by: Balazs Kutil bkutil@suse.com
