### PR TITLE
Add rake to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 # Explicitly requiring test/unit here so that testing works on Ruby 1.9
 group :test do
   gem 'rspec'
+  gem 'rake'
 end


### PR DESCRIPTION
On many CI servers machines are bootstraped from scratch. When we use bundler:

```

An exception occurred running /home/lite/.rvm/gems/rbx-head/bin/rake
    rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)

Backtrace:
  { } in Kernel(Object)#replace_gem at /home/lite/.rvm/gems/rbx-head/gems/bundler-1.1.3/lib/bundler/rubygems_integration.rb:147
                  Object#__script__ at /home/lite/.rvm/gems/rbx-head/bin/rake:18
   Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:67
   Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:109
            Rubinius::Loader#script at kernel/loader.rb:640
              Rubinius::Loader#main at kernel/loader.rb:844
```

Without rake on Gemfile travis-ci do not execute specs.
