### PR TITLE
Fix specs for ruby 1.9

### DIFF
--- a/lib/scanny/issue.rb
+++ b/lib/scanny/issue.rb
@@ -17,7 +17,7 @@ module Scanny
 
     def to_s
       cwe_suffix = if @cwe
-        " (" + @cwe.to_a.map { |cwe| "CWE-#{cwe}" }.join(", ") + ")"
+        " (" + Array(@cwe).map { |cwe| "CWE-#{cwe}" }.join(", ") + ")"
       else
         ""
       end


### PR DESCRIPTION
Ruby 1.8

```
1.8.7 :001 > 10.to_a
(irb):1: warning: default `to_a' will be obsolete
 => [10] 
```

Ruby 1.9.x

```
101.9.3p125 :001 > 10.to_a
NoMethodError: undefined method `to_a' for 10:Fixnum
    from (irb):1
    from /home/lite/.rvm/rubies/ruby-1.9.3-p125-perf/bin/irb:16:in `<main>'
```

There is also error with rubinius (XPath matcher for rspec). I created pull request for that (https://github.com/rubinius/rubinius/issues/1743)
