### PR TITLE
Ruby version check

### DIFF
--- a/lib/scanny.rb
+++ b/lib/scanny.rb
@@ -1,3 +1,4 @@
+require_relative "scanny/ruby_version_check"
 require_relative "scanny/issue"
 require_relative "scanny/report"
 require_relative "scanny/runner"

--- a/lib/scanny/issue.rb
+++ b/lib/scanny/issue.rb
@@ -17,7 +17,7 @@ module Scanny
 
     def to_s
       cwe_suffix = if @cwe
-        " (" + @cwe.to_a.map { |cwe| "CWE-#{cwe}" }.join(", ") + ")"
+        " (" + Array(@cwe).map { |cwe| "CWE-#{cwe}" }.join(", ") + ")"
       else
         ""
       end

--- a/lib/scanny/ruby_version_check.rb
+++ b/lib/scanny/ruby_version_check.rb
@@ -1,0 +1,15 @@
+unless defined?(RUBY_ENGINE) && RUBY_ENGINE == "rbx" && RUBY_VERSION >= '1.9'
+  desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
+  abort <<-end_message
+
+      Scanny requires Rubinius in 1.9 mode.
+
+      You're running
+        #{desc}
+
+      Please change your Ruby implementation to continue.
+
+  end_message
+
+  raise abort
+end

--- a/spec/scanny/ruby_version_check_spec.rb
+++ b/spec/scanny/ruby_version_check_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "Ruby version check" do
+
+  before { @load_file = "scanny/ruby_version_check.rb" }
+
+  it "should raise exception (ruby 1.8)" do
+    -> {load_with('ruby', '1.8', @load_file)}.should raise_error
+  end
+
+  it "should raise exception (ruby 1.9)" do
+    -> {load_with('ruby', '1.9', @load_file)}.should raise_error
+  end
+
+  it "should raise exception (rbx 1.8 mode)" do
+    -> {load_with('rbx', '1.8', @load_file)}.should raise_error
+  end
+
+  it "should not raise exception (rbx 1.9 mode)" do
+    -> {load_with('rbx', '1.9', @load_file)}.should_not raise_error
+  end
+
+end
+

--- a/spec/scanny/ruby_version_check_spec.rb
+++ b/spec/scanny/ruby_version_check_spec.rb
@@ -5,19 +5,19 @@ describe "Ruby version check" do
   before { @load_file = "scanny/ruby_version_check.rb" }
 
   it "should raise exception (ruby 1.8)" do
-    -> {load_with('ruby', '1.8', @load_file)}.should raise_error
+    -> { load_with('ruby', '1.8', @load_file) }.should raise_error
   end
 
   it "should raise exception (ruby 1.9)" do
-    -> {load_with('ruby', '1.9', @load_file)}.should raise_error
+    -> { load_with('ruby', '1.9', @load_file) }.should raise_error
   end
 
   it "should raise exception (rbx 1.8 mode)" do
-    -> {load_with('rbx', '1.8', @load_file)}.should raise_error
+    -> { load_with('rbx', '1.8', @load_file) }.should raise_error
   end
 
   it "should not raise exception (rbx 1.9 mode)" do
-    -> {load_with('rbx', '1.9', @load_file)}.should_not raise_error
+    -> { load_with('rbx', '1.9', @load_file) }.should_not raise_error
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,6 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |c|
   c.include CheckSpecHelpers
+  c.include ConstSpecHelpers
   c.color_enabled = true
 end

--- a/spec/support/const_spec_helpers.rb
+++ b/spec/support/const_spec_helpers.rb
@@ -1,0 +1,36 @@
+module ConstSpecHelpers
+  def with_const(const, &block)
+    saved_const = {}
+    const.each do |const, val|
+      saved_const[const] = Object.const_get(const)
+      Object.const_set(const, val)
+    end
+
+    begin
+      block.call
+    ensure
+      const.each do |const, _|
+        Object.const_set(const, saved_const[ const ])
+      end
+    end
+  end
+
+  def with_ruby(engine = "rbx", version = '1.9.3', &block)
+    with_const(:RUBY_VERSION => version,:RUBY_ENGINE => engine, &block)
+  end
+
+  def silence
+    orig_stdout = $stderr
+    $stderr = File.new('/dev/null', 'w')
+    yield
+  ensure
+    $stderr = orig_stdout
+  end
+
+  def load_with(engine, version, file)
+    silence do
+      with_ruby(engine, version) { load(file) }
+    end
+  end
+end
+

--- a/spec/support/const_spec_helpers.rb
+++ b/spec/support/const_spec_helpers.rb
@@ -1,16 +1,16 @@
 module ConstSpecHelpers
   def with_const(const, &block)
-    saved_const = {}
+    saved_consts = {}
     const.each do |const, val|
-      saved_const[const] = Object.const_get(const)
+      saved_consts[const] = Object.const_get(const)
       Object.const_set(const, val)
     end
 
     begin
       block.call
     ensure
-      const.each do |const, _|
-        Object.const_set(const, saved_const[ const ])
+      const.each_key do |const|
+        Object.const_set(const, saved_consts[ const ])
       end
     end
   end


### PR DESCRIPTION
Non rubinius implementation

```
> rvm default
> bin/scanny 

      Scanny requires rubinius in 1.9 mode.

      You're running
        ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-linux]

      Please upgrade to continue.

```

Rubinius

```
> rvm rbx-head
> ruby bin/scanny 

Found no issues.
```
