### PR TITLE
Bump machete version.

### DIFF
--- a/scanny.gemspec
+++ b/scanny.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "scanny"
 
-  s.add_dependency "machete", "~> 0.3.0"
+  s.add_dependency "machete", "~> 0.4.0"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact


### PR DESCRIPTION
Scanny use new feature of machete matching
method names with regexp. In future will use DSL.
