### PR TITLE
Check is there is issues. Because array[0] can raise exception

### DIFF
--- a/spec/support/matchers/check_matcher.rb
+++ b/spec/support/matchers/check_matcher.rb
@@ -24,7 +24,7 @@ RSpec::Matchers.define :check do |input|
         report.issues.size.should == @count
 
       when :issue
-        report.issues.size.should == 1
+        report.issues.size.should > 0
         report.issues[0].should == @issue
 
       else


### PR DESCRIPTION
From time to time we have checks:

```
low             CWE-20                  logger\.\w+\s*[\(]*.*params\s*\[
low             CWE-20                  params\s*\[:
```

``` ruby
logger(params[:password]) # one check
```

and other (the same message, CWE and impact level)

``` ruby
params[:password]
```

Scanny report two times issue because find whole `logger(params[:password])` and only `params[:password]`.
