### PR TITLE
Fixes incorrectly used for any* [updated]

### DIFF
--- a/lib/scanny/checks/denial_of_service_check.rb
+++ b/lib/scanny/checks/denial_of_service_check.rb
@@ -22,16 +22,15 @@ module Scanny
           SendWithArguments<
             arguments = ActualArguments<
               array = [
-                any*,
+                any{1,},
                 HashLiteral<
                   array = [
-                    any*,
+                    any{even},
                     SymbolLiteral<value = :limit | :conditions>,
                     StringLiteral<string *= 'LIKE'>,
-                    any*
+                    any{even}
                   ]
-                >,
-                any*
+                >
               ]
             >,
             name *= /^find/

--- a/lib/scanny/checks/sql_injection/find_method_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_check.rb
@@ -57,17 +57,16 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any*,
+                  any{1,},
                   HashLiteral<
                     array = [
-                      any*,
+                      any{even},
                       SymbolLiteral<
                         value = :conditions
                       >,
-                      any*
+                      any{odd}
                     ]
-                  >,
-                  any*
+                  >
                 ]
               >,
               name = :find

--- a/lib/scanny/checks/sql_injection/find_method_with_dynamic_string_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_dynamic_string_check.rb
@@ -22,16 +22,15 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any*,
+                  any{1,},
                   HashLiteral<
                     array = [
-                      any*,
+                      any{even},
                       SymbolLiteral<value = :conditions>,
                       DynamicString,
-                      any*
+                      any{even}
                     ]
-                  >,
-                  any*
+                  >
                 ]
               >,
               name = :find

--- a/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
@@ -45,20 +45,18 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any*,
+                  any{1,},
                   HashLiteral<
                     array = [
-                      any*,
+                      any{even},
                       SymbolLiteral<value = :limit | :conditions>,
-                      any*,
                       SendWithArguments<
                         name = :[],
                         receiver = Send<name = :params | :session>
                       >,
-                      any*
+                      any{even}
                     ]
-                  >,
-                  any*
+                  >
                 ]
               >,
               name = :find>

--- a/lib/scanny/checks/verify_check.rb
+++ b/lib/scanny/checks/verify_check.rb
@@ -22,15 +22,13 @@ module Scanny
           SendWithArguments<
             arguments = ActualArguments<
               array = [
-                any*,
                 HashLiteral<
                   array = [
-                    any*,
+                    any{even},
                     SymbolLiteral<value = :method>,
-                    any*
+                    any{odd}
                   ]
-                >,
-                any*
+                >
               ]
             >,
             name = :verify

--- a/lib/scanny/checks/xss/xss_send_check.rb
+++ b/lib/scanny/checks/xss/xss_send_check.rb
@@ -25,6 +25,7 @@ module Scanny
           name = :send_file | :send_data,
           arguments = ActualArguments<
             array = [
+              any,
               HashLiteral<
                 array = [
                   SymbolLiteral<value   = :disposition>,

--- a/spec/scanny/checks/denial_of_service_check_spec.rb
+++ b/spec/scanny/checks/denial_of_service_check_spec.rb
@@ -12,11 +12,17 @@ module Scanny::Checks
     it "reports \"User.find(:first, :conditions => \"name LIKE '%bob%'\" )\" correctly" do
       @runner.should  check("User.find(:first, :conditions => \"name LIKE '%bob%'\" )").
                       with_issue(@issue)
+      @runner.should  check("User.find(:conditions => \"name LIKE '%bob%'\")").
+                      without_issues
     end
 
     it "reports \"User.find(:first, :limit => \"name LIKE '%bob%'\" )\" correctly" do
       @runner.should  check("User.find(:first, :limit => \"name LIKE '%bob%'\" )").
-                          with_issue(@issue)
+                      with_issue(@issue)
+      @runner.should  check("User.find(:limit => \"name LIKE '%bob%'\")").
+                      without_issues
     end
+
+
   end
 end

--- a/spec/scanny/checks/sql_injection/find_method_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_check_spec.rb
@@ -14,6 +14,16 @@ module Scanny::Checks::Sql
                       with_issue(@issue_low)
     end
 
+    it "does not report \"find\" calls without first argument" do
+      @runner.should  check("find(:conditions => { :id => 10 })").
+                      without_issues
+    end
+
+    it "does not report \"find\" with wrong key" do
+      @runner.should  check("find(:first, :hello => :conditions)").
+                      without_issues
+    end
+
     it "reports \"find\" calls with :conditions key and dynamic value correctly" do
       @runner.should  check('find(:first, :conditions => "#{method}")').
                       with_issue(@issue_low)

--- a/spec/scanny/checks/sql_injection/find_method_with_dynamic_string_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_with_dynamic_string_check_spec.rb
@@ -11,8 +11,17 @@ module Scanny::Checks::Sql
 
     it "reports \"find\" calls with :conditions key and dynamic value correctly" do
       @runner.should  check('find(:first, :conditions => "#{method}")').
-                          with_issue(@issue_medium)
+                      with_issue(@issue_medium)
       @runner.should check('find(:first, :conditions => "normal_string")').without_issues
+    end
+
+    it "does not report \"find\" calls without first argument" do
+      @runner.should check("find(:conditions => :value)").without_issues
+    end
+
+    it "does not report \"find\" calls with incorrect hash value" do
+      @runner.should  check('find(:first, "#{conditions}" => :value)').
+                      without_issues
     end
   end
 end

--- a/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
@@ -37,6 +37,16 @@ module Scanny::Checks::Sql
                           with_issue(@issue_high)
     end
 
+    it "does not report \"find\" calls when no first argument is given" do
+      @runner.should  check("find(:limit => session[:password])").
+                      without_issues
+    end
+
+    it "does not report \"find\" when hash keys are incorrect" do
+      @runner.should  check("find(:first, :key => :limit, params[:hello] => :value)").
+                      without_issues
+    end
+
     it "reports \"execute\" calls on class with params correctly" do
       @runner.should check('User.execute params[:password]').with_issue(@issue_high)
     end

--- a/spec/scanny/checks/verify_check_spec.rb
+++ b/spec/scanny/checks/verify_check_spec.rb
@@ -18,5 +18,10 @@ module Scanny::Checks
       @runner.should  check("verify :params => 'user', :only => :update_password").
                       without_issues
     end
+
+    it "does not report \"verify :argument, :method => :post\"" do
+      @runner.should  check("verify :argument, :method => :post").
+                      without_issues
+    end
   end
 end

--- a/spec/scanny/checks/xss/xss_send_check_spec.rb
+++ b/spec/scanny/checks/xss/xss_send_check_spec.rb
@@ -9,13 +9,13 @@ module Scanny::Checks
     end
 
     it "reports \"send_file :disposition => 'inline'\" correctly" do
-      @runner.should check("send_file :disposition => 'inline' ").with_issue(@issue)
-      @runner.should check("send_file :disposition => 'attachment' ").without_issues
+      @runner.should check("send_file 'file', :disposition => 'inline' ").with_issue(@issue)
+      @runner.should check("send_file 'file', :disposition => 'attachment' ").without_issues
     end
 
     it "reports \"send_data :disposition => 'inline'\" correctly" do
-      @runner.should check("send_data :disposition => 'inline' ").with_issue(@issue)
-      @runner.should check("send_data :disposition => 'attachment' ").without_issues
+      @runner.should check("send_data 'file', :disposition => 'inline' ").with_issue(@issue)
+      @runner.should check("send_data 'file', :disposition => 'attachment' ").without_issues
     end
   end
 end


### PR DESCRIPTION
In rails 2.3.x find method hash always should be on second place
Verify method should work only with hash argument
Update check for find method. Proper use HashLiteral with any
Update check for find with dynamic string.
Remove unnecessary any\* between SymbolLiteral and SendWithArguments.
This pattern also recognize {:limit => (any), params[:hello] => :value}.
Method send_file should be always executed with name of file to send
Don't use any\* for ActiveRecord .find method

Updated version of #73
