### PR TITLE
Remove empty patterns

### DIFF
--- a/lib/scanny/checks/http_request_check.rb
+++ b/lib/scanny/checks/http_request_check.rb
@@ -15,7 +15,7 @@ module Scanny
       private
 
       def warning_message
-        "Connecting to the server without encryption" +
+        "Connecting to the server without encryption " +
         "can facilitate sniffing traffic"
       end
 
@@ -35,7 +35,18 @@ module Scanny
       # Net::HTTP::Proxy('proxy.example.com', 8080)
       def pattern_net_http_proxy
         <<-EOT
-          Send | SendWithArguments
+          Send
+          <
+            receiver = ScopedConstant<
+              parent = ConstantAccess<
+                name = :Net
+              >,
+              name = :HTTP
+            >,
+            name = :Proxy
+          >
+          |
+          SendWithArguments
           <
             receiver = ScopedConstant<
               parent = ConstantAccess<

--- a/lib/scanny/checks/http_usage_check.rb
+++ b/lib/scanny/checks/http_usage_check.rb
@@ -12,7 +12,7 @@ module Scanny
       private
 
       def warning_message
-        "Connecting to the server without encryption" +
+        "Connecting to the server without encryption " +
         "can facilitate sniffing traffic"
       end
 

--- a/lib/scanny/checks/insecure_method/deserialize_method_check.rb
+++ b/lib/scanny/checks/insecure_method/deserialize_method_check.rb
@@ -19,8 +19,9 @@ module Scanny
         # deserialize()
         def pattern_deserialize_call
           <<-EOT
-            SendWithArguments | Send
-              <name = :deserialize>
+            SendWithArguments<name = :deserialize>
+            |
+            Send<name = :deserialize>
           EOT
         end
       end

--- a/lib/scanny/checks/insecure_method/eval_method_check.rb
+++ b/lib/scanny/checks/insecure_method/eval_method_check.rb
@@ -19,8 +19,9 @@ module Scanny
         # eval("ruby_code")
         def pattern_eval_call
           <<-EOT
-            SendWithArguments | Send
-              <name = :eval>
+            SendWithArguments<name = :eval>
+            |
+            Send<name = :eval>
           EOT
         end
       end

--- a/lib/scanny/checks/insecure_method/system_method_check.rb
+++ b/lib/scanny/checks/insecure_method/system_method_check.rb
@@ -23,7 +23,16 @@ module Scanny
         # system("rm -rf /")
         def pattern_system_calls
           <<-EOT
-            SendWithArguments | Send
+            SendWithArguments
+              <name =
+                :popen          |
+                :system         |
+                :spawn          |
+                :exec           |
+                :queue_command
+              >
+            |
+            Send
               <name =
                 :popen          |
                 :system         |

--- a/lib/scanny/checks/ssl/verify_check.rb
+++ b/lib/scanny/checks/ssl/verify_check.rb
@@ -37,9 +37,15 @@ module Scanny
         # ca_file
         def pattern_ca_file
           <<-EOT
-          LocalVariableAssignment | InstanceVariableAssignment
+          InstanceVariableAssignment
           <
-            name = :ca_file | :ca_path | :@ca_file | :@ca_path,
+            name = :@ca_file | :@ca_path,
+            value = NilLiteral
+          >
+          |
+          LocalVariableAssignment
+          <
+            name = :ca_file | :ca_path,
             value = NilLiteral
           >
           EOT

--- a/lib/scanny/checks/system_tools/gpg_usage_check.rb
+++ b/lib/scanny/checks/system_tools/gpg_usage_check.rb
@@ -25,7 +25,7 @@ module Scanny
         # GPG.method
         def pattern_gpg_class
           <<-EOT
-          Send | SendWithArguments
+          Send
           <
             receiver = ConstantAccess<
               name =
@@ -34,13 +34,22 @@ module Scanny
                 :GpgKey
             >
           >
-
+          |
+          SendWithArguments
+          <
+            receiver = ConstantAccess<
+              name =
+                :GPG |
+                :Gpg |
+                :GpgKey
+            >
+          >
           EOT
         end
 
         # gpg()
         def pattern_gpg_method
-          "Send | SendWithArguments<name = :gpg>"
+          "Send<name = :gpg> | SendWithArguments<name = :gpg>"
         end
       end
     end

--- a/lib/scanny/checks/temp_file_open_check.rb
+++ b/lib/scanny/checks/temp_file_open_check.rb
@@ -52,7 +52,12 @@ module Scanny
       # Tempfile.new
       def pattern_tempfile
         <<-EOT
-          Send | SendWithArguments<
+          Send<
+            name = :new,
+            receiver = ConstantAccess<name = :Tempfile>
+          >
+          |
+          SendWithArguments<
             name = :new,
             receiver = ConstantAccess<name = :Tempfile>
           >

--- a/spec/scanny/checks/http_request_check_spec.rb
+++ b/spec/scanny/checks/http_request_check_spec.rb
@@ -4,7 +4,7 @@ module Scanny::Checks
   describe HTTPRequestCheck do
     before do
       @runner = Scanny::Runner.new(HTTPRequestCheck.new)
-      @message =  "Connecting to the server without encryption" +
+      @message =  "Connecting to the server without encryption " +
           "can facilitate sniffing traffic"
       @issue = issue(:low, @message, 441)
     end

--- a/spec/scanny/checks/http_usage_check_spec.rb
+++ b/spec/scanny/checks/http_usage_check_spec.rb
@@ -4,7 +4,7 @@ module Scanny::Checks
   describe HTTPUsageCheck do
     before do
       @runner = Scanny::Runner.new(HTTPUsageCheck.new)
-      @message =  "Connecting to the server without encryption" +
+      @message =  "Connecting to the server without encryption " +
                   "can facilitate sniffing traffic"
       @issue = issue(:low, @message, 319)
     end

--- a/spec/scanny/cli_spec.rb
+++ b/spec/scanny/cli_spec.rb
@@ -54,7 +54,7 @@ describe "Command line interface" do
 
       it { assert_partial_output "check loaded", all_stdout }
       it { assert_no_partial_output "check2 loaded", all_stdout }
-      it { assert_exit_status 1 }
+      it { assert_exit_status 0 }
     end
 
     describe "when given --include argument with many directories" do
@@ -62,7 +62,7 @@ describe "Command line interface" do
 
       it { assert_partial_output "check loaded", all_stdout }
       it { assert_partial_output "check2 loaded", all_stdout }
-      it { assert_exit_status 1 }
+      it { assert_exit_status 0 }
     end
   end
 


### PR DESCRIPTION
For example:

``` ruby
Send | SendWithArguments<name = :method_name>
```

Will recognize `method_name(:argument)` and any method call.
Proper pattern for this:

``` ruby
Send<name = :method_name> | SendWithArguments<name = :method_name>
```
