### PR TITLE
Don't print empty issues

### DIFF
--- a/lib/scanny/reporters/simple_reporter.rb
+++ b/lib/scanny/reporters/simple_reporter.rb
@@ -10,7 +10,7 @@ module Scanny
         issues.each do |issue|
           string += "\n  - #{issue.to_s}"
         end
-        puts string
+        puts string unless issues.empty?
 
         string
       end


### PR DESCRIPTION
When scanny not recognize the pattern should not print file name with **0 issues** on screen
