### PR TITLE
Add empty file to check.

### DIFF
--- a/spec/scanny/cli_spec.rb
+++ b/spec/scanny/cli_spec.rb
@@ -1,7 +1,11 @@
 require "spec_helper"
 
 describe "Command line interface" do
-  before { @help_message_prefix = "Scanny RoR secutiry scanner" }
+  before(:all) do
+    @help_message_prefix = "Scanny RoR secutiry scanner"
+    @aruba_timeout_seconds = 10
+  end
+
   after { FileUtils.rm_rf(File.expand_path("../../../tmp", __FILE__)) }
 
   describe "when given --help argument" do
@@ -47,6 +51,7 @@ describe "Command line interface" do
     before do
       write_file('./checks/check.rb', 'puts "check loaded"')
       write_file('./checks2/check.rb', 'puts "check2 loaded"')
+      write_file('./app/project.rb', 'puts("hello world")')
     end
 
     describe "when given --include argument with one directory" do


### PR DESCRIPTION
After change default directory, specs can't parse any file and try
execute `each` method on `NilClass`. New version of rubiniues need more
time for CLI specs. Bump wait timeout for CI specs.
