### PR TITLE
Proper behavior for empty files list

### DIFF
--- a/lib/scanny/runner.rb
+++ b/lib/scanny/runner.rb
@@ -12,6 +12,8 @@ module Scanny
       else
         @checks = checks
       end
+
+      @checks_data = []
     end
 
     def check(file, input)
@@ -42,7 +44,7 @@ module Scanny
 
     def check_file(file)
       @file = file
-      (@checks_data ||= []) << check(file, File.read(file))
+      @checks_data << check(file, File.read(file))
     end
 
     def check_files(*files)

--- a/spec/scanny/runner_spec.rb
+++ b/spec/scanny/runner_spec.rb
@@ -25,6 +25,11 @@ module Scanny
         checks.any? { |ch| ch.class == Checks::ExtendCheck }.should be_false
         checks.any? { |ch| ch.class == Checks::MyCheck }.should be_true
       end
+
+      it "initializes checks_data on start" do
+        runner = Runner.new
+        runner.checks_data.should_not be_nil
+      end
     end
 
     describe "check" do


### PR DESCRIPTION
Scanny will not raise exception when there is no files to scan
