### PR TITLE
Transform to ast with ruby 1.8 fallback

### DIFF
--- a/lib/scanny/runner.rb
+++ b/lib/scanny/runner.rb
@@ -17,7 +17,7 @@ module Scanny
     end
 
     def check(file, input)
-      ast               = input.to_ast
+      ast               = transform_to_ast(input)
       ignored_lines     = extract_ignored_lines(input)
       checks_performed  = 0
       nodes_inspected   = 0
@@ -40,6 +40,13 @@ module Scanny
         :nodes_inspected    => nodes_inspected,
         :file               => file
       }
+    end
+
+    def transform_to_ast(input)
+      input.to_ast
+    rescue SyntaxError
+      # fallback for ruby 1.8
+      Rubinius::Melbourne.new("(eval)", 1).parse_string(input)
     end
 
     def check_file(file)

--- a/spec/scanny/runner_spec.rb
+++ b/spec/scanny/runner_spec.rb
@@ -123,6 +123,24 @@ module Scanny
       end
     end
 
+    describe "transform_to_ast" do
+      it "parses proper input" do
+        @runner.transform_to_ast("1+1").should be_kind_of(Rubinius::AST::SendWithArguments)
+      end
+
+      it "raises SyntaxError in case of invalid syntax" do
+        lambda {
+          @runner.transform_to_ast("+1+")
+        }.should raise_error(SyntaxError)
+      end
+
+      it "fallbacks to ruby 1.8 syntax" do
+        lambda {
+          @runner.transform_to_ast("case sym;when :mysql:  PathFinder::Mysql::Options; end")
+        }.should_not raise_error
+      end
+    end
+
     # We don't test #check_file since it's just a tiny wrapper around #check.
   end
 end


### PR DESCRIPTION
When Rubinius can't parse ruby file raise SyntaxError. But from time to time file is compiled only with ruby 1.8. Now scanny have fallback to 1.8 parser.
