### PR TITLE
Parser mode for scanny

### DIFF
--- a/bin/scanny
+++ b/bin/scanny
@@ -14,14 +14,17 @@ Options:
   -i <check>, --include <check>     Include check to scanning process (file or directory).
   -d <check>, --disable <check>     Disable check class from scanning process.
   -f <format>, --format <format>    Output format (stdout, html, xml) [default: stdout].
-  -s, --strict                      Enable strict mode (for security guys) [default: false]."
+  -s, --strict                      Enable strict mode (for security guys) [default: false].
+  -m <mode>, --mode <mode>          Ruby parser mode (18 or 19) [default: 19]"
 
 
 options = Docopt(doc)
 
 require_checks(options[:include])
 
-runner  = runner_with_custom_checks(options[:disable], options[:strict])
+runner = Scanny::Runner.new(:parser => use_parser(options[:mode]))
+
+runner_with_custom_checks(runner, options[:disable], options[:strict])
 issues  = 0
 
 files = build_paths.map { |arg| Dir[arg].to_a }.flatten

--- a/lib/scanny/cli.rb
+++ b/lib/scanny/cli.rb
@@ -20,16 +20,28 @@ module Scanny
       end
     end
 
-    def runner_with_custom_checks(disabled_checks, strict = false)
+    def runner_with_custom_checks(runner, disabled_checks, strict = false)
       disabled_checks = disabled_checks.to_s.split(",").map(&:strip)
 
-      runner = Scanny::Runner.new
       runner.checks.reject! do |check|
         disabled_checks.any? { |ch| check.class.name == ch } ||
         (check.strict? && !strict)
       end
 
       runner
+    end
+
+    def use_parser(version)
+      return unless version
+      case version
+        when '18'
+          Rubinius::Melbourne
+        when '19'
+          Rubinius::Melbourne19
+        else
+          $stderr.puts "I can not recognize the version of the parser: #{version}"
+          exit 2
+      end
     end
   end
 end

--- a/lib/scanny/runner.rb
+++ b/lib/scanny/runner.rb
@@ -4,9 +4,11 @@ require "ostruct"
 
 module Scanny
   class Runner
-    attr_reader :checks, :checks_data, :file
+    attr_reader :checks, :checks_data, :file, :parser
 
     def initialize(*checks)
+      options = checks.last.is_a?(Hash) ? checks.pop : {}
+
       if checks.empty?
         @checks = check_classes
       else
@@ -14,10 +16,11 @@ module Scanny
       end
 
       @checks_data = []
+      @parser = options[:parser] || Rubinius::Melbourne19
     end
 
     def check(file, input)
-      ast               = input.to_ast
+      ast               = parser.new("(eval)", 1).parse_string(input)
       ignored_lines     = extract_ignored_lines(input)
       checks_performed  = 0
       nodes_inspected   = 0

--- a/spec/scanny/cli_spec.rb
+++ b/spec/scanny/cli_spec.rb
@@ -127,4 +127,28 @@ describe "Command line interface" do
       it { assert_exit_status 1 }
     end
   end
+
+  context "parser mode" do
+    before { write_file("check.rb", "case s;when :m: P; end") }
+
+    describe "when given --mode 18 argument" do
+      before { run 'scanny --mode 18 ./check.rb' }
+      it { assert_no_partial_output "Can't parse ./check.rb as Ruby file", all_stderr }
+    end
+
+    describe "when given --mode 19 argument" do
+      before { run 'scanny --mode 19 ./check.rb' }
+      it { assert_partial_output "Can't parse ./check.rb as Ruby file", all_stderr }
+    end
+
+    describe "when given --mode invalid argument" do
+      before do
+        @message = "I can not recognize the version of the parser: invalid"
+        run 'scanny --mode invalid ./check'
+      end
+
+      it { assert_partial_output @message, all_stderr }
+      it { assert_exit_status 2 }
+    end
+  end
 end


### PR DESCRIPTION
User can select parser. For example old applications need to use 1.8 parser.

```
scanny --mode 18 ./my/app
```

or 

```
scanny --mode 19 ./my/app
```
