### PR TITLE
ActiveRecord objects (create with hash pattern)

### DIFF
--- a/lib/scanny/checks/mass_assignment_check.rb
+++ b/lib/scanny/checks/mass_assignment_check.rb
@@ -26,6 +26,17 @@ module Scanny
                   name = :[],
                   receiver = Send<name = :params>
                 >
+                |
+                HashLiteral<
+                array = [
+                  any{odd},
+                  SendWithArguments<
+                    name = :[],
+                    receiver = Send<name = :params>
+                  >,
+                  any{even}
+                ]
+                >
               ]
             >,
             name = :new | :create | :update_attributes

--- a/spec/scanny/checks/mass_assignment_check_spec.rb
+++ b/spec/scanny/checks/mass_assignment_check_spec.rb
@@ -13,6 +13,11 @@ module Scanny::Checks
       @runner.should check("User.new(params[:user])").with_issue(@issue)
     end
 
+    it "reports \"User.new(:email => params[:input])\" correctly" do
+      @runner.should check("User.new(:email => params[:input])").with_issue(@issue)
+      @runner.should check("User.new(params[:input] => :value)").without_issues
+    end
+
     it "reports \"User.create(params[:user])\" correctly" do
       @runner.should check("User.create(params[:user])").with_issue(@issue)
     end


### PR DESCRIPTION
Pattern should recognize hash

ActiveRecord object developers usually create via hash arguments.
Pattern should recognize #params in values field in hash.

Issue #10
Related to https://github.com/openSUSE/scanny/issues/10#issuecomment-7526102
