### PR TITLE
Update check for sanitize_sql

### DIFF
--- a/lib/scanny/checks/sql_injection/sanitize_sql_check.rb
+++ b/lib/scanny/checks/sql_injection/sanitize_sql_check.rb
@@ -17,7 +17,7 @@ module Scanny
 
         # sanitize_sql()
         def pattern_sanitize_sql
-          "Send<name = :sanitize_sql>"
+          "SendWithArguments<name = :sanitize_sql>"
         end
       end
     end

--- a/spec/scanny/checks/sql_injection/sanitize_sql_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/sanitize_sql_check_spec.rb
@@ -10,7 +10,7 @@ module Scanny::Checks::Sql
     end
 
     it "reports \"sanitize_sql\" calls correctly" do
-      @runner.should check("'mysql_query'.sanitize_sql").with_issue(@issue_info)
+      @runner.should check("sanitize_sql('mysql_query')").with_issue(@issue_info)
     end
   end
 end


### PR DESCRIPTION
According to the documentation, we need always execute methods with arguments. So pattern should use `SendWithArguments` instead of `Send`.

Related to https://github.com/openSUSE/scanny/issues/7#issuecomment-7613169
Issue #7
