### PR TITLE
Find method fix

### DIFF
--- a/lib/scanny/checks/sql_injection/find_method_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_check.rb
@@ -21,11 +21,13 @@ module Scanny
         private
 
         # User.find_by_sql
+        # @collection.paginate(options)
         def pattern_find_by_sql_and_execute_on_models
           <<-EOT
-            Send<
-              name = :execute | :find_by_sql | :paginate,
-              receiver = ConstantAccess
+            Send<name = :paginate>
+            |
+            SendWithArguments<
+              name = :execute | :find_by_sql | :paginate
             >
           EOT
         end

--- a/spec/scanny/checks/sql_injection/find_method_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_check_spec.rb
@@ -35,15 +35,23 @@ module Scanny::Checks::Sql
     end
 
     it "reports \"execute\" calls on class correctly" do
-      @runner.should check('User.execute').with_issue(@issue_low)
+      @runner.should check('User.execute("sql")').with_issue(@issue_low)
     end
 
     it "reports \"find_by_sql\" calls on class correctly" do
-      @runner.should check('User.find_by_sql').with_issue(@issue_low)
+      @runner.should check('User.find_by_sql("sql")').with_issue(@issue_low)
     end
 
     it "reports \"paginate\" calls on class correctly" do
       @runner.should check('User.paginate').with_issue(@issue_low)
+    end
+
+    it "reports \"paginage\" calls on object correctly" do
+      @runner.should check("array.paginate").with_issue(@issue_low)
+    end
+
+    it "reports \"paginage\" calls on object with arguments correctly" do
+      @runner.should check("array.paginate(options)").with_issue(@issue_low)
     end
 
     it "reports \"find_by_sql\" calls on class with params correctly" do


### PR DESCRIPTION
Methods :find_by_sql and :execute should be executes with arguments. But
:paginate method can be executed with and without arguments. Pattern
also should not check only execution on constants. Because for example
:paginate can be executed on collection.

Related to https://github.com/openSUSE/scanny/issues/7#issuecomment-7613465
Issue #7
