### PR TITLE
Add subpattern for "/tmp/"

### DIFF
--- a/lib/scanny/checks/temp_file_open_check.rb
+++ b/lib/scanny/checks/temp_file_open_check.rb
@@ -3,6 +3,7 @@ module Scanny
     class TempFileOpenCheck < Check
       def pattern
         [
+          pattern_temp,
           pattern_file_open,
           pattern_mkdir_p,
           pattern_tempfile
@@ -57,6 +58,10 @@ module Scanny
             receiver = ConstantAccess<name = :Tempfile>
           >
         EOT
+      end
+
+      def pattern_temp
+        'StringLiteral<string *= /\/tmp\//>'
       end
     end
   end

--- a/spec/scanny/checks/temp_file_open_check_spec.rb
+++ b/spec/scanny/checks/temp_file_open_check_spec.rb
@@ -11,12 +11,12 @@ module Scanny::Checks
 
     it "reports \"File.open('/home/app/tmp/file')\" correctly" do
       @runner.should  check("File.open('/home/app/tmp/file')").
-                      with_issue(@issue)
+                      with_issues([@issue, @issue])
     end
 
     it "reports \"mkdir_p('/rails/tmp/my/dir')\" correctly" do
       @runner.should  check("mkdir_p('/rails/tmp/my/dir')").
-                      with_issue(@issue)
+                      with_issues([@issue, @issue])
     end
 
     it "reports \"Tempfile.new\" correctly" do


### PR DESCRIPTION
Implementation don't have subpattern for `/tmp/` string.

Related to https://github.com/openSUSE/scanny/issues/14#issuecomment-7612646
Issue #14
