### PR TITLE
Remove Tempfile.new from patterns

### DIFF
--- a/lib/scanny/checks/temp_file_open_check.rb
+++ b/lib/scanny/checks/temp_file_open_check.rb
@@ -3,6 +3,7 @@ module Scanny
     class TempFileOpenCheck < Check
       def pattern
         [
+          pattern_temp,
           pattern_file_open,
           pattern_mkdir_p,
           pattern_tempfile
@@ -57,6 +58,10 @@ module Scanny
             receiver = ConstantAccess<name = :Tempfile>
           >
         EOT
+      end
+
+      def pattern_temp
+        'StringLiteral<string *= /\/tmp\//>'
       end
     end
   end

--- a/lib/scanny/checks/temp_file_open_check.rb
+++ b/lib/scanny/checks/temp_file_open_check.rb
@@ -5,8 +5,7 @@ module Scanny
         [
           pattern_temp,
           pattern_file_open,
-          pattern_mkdir_p,
-          pattern_tempfile
+          pattern_mkdir_p
         ].join("|")
       end
 
@@ -46,16 +45,6 @@ module Scanny
               ]
             >,
             name = :mkdir_p
-          >
-        EOT
-      end
-
-      # Tempfile.new
-      def pattern_tempfile
-        <<-EOT
-          SendWithArguments<
-            name = :new,
-            receiver = ConstantAccess<name = :Tempfile>
           >
         EOT
       end

--- a/spec/scanny/checks/temp_file_open_check_spec.rb
+++ b/spec/scanny/checks/temp_file_open_check_spec.rb
@@ -18,10 +18,5 @@ module Scanny::Checks
       @runner.should  check("mkdir_p('/rails/tmp/my/dir')").
                       with_issues([@issue, @issue])
     end
-
-    it "reports \"Tempfile.new\" correctly" do
-      @runner.should check("Tempfile.new").without_issues
-      @runner.should check("Tempfile.new('foo')").with_issue(@issue)
-    end
   end
 end

--- a/spec/scanny/checks/temp_file_open_check_spec.rb
+++ b/spec/scanny/checks/temp_file_open_check_spec.rb
@@ -11,12 +11,12 @@ module Scanny::Checks
 
     it "reports \"File.open('/home/app/tmp/file')\" correctly" do
       @runner.should  check("File.open('/home/app/tmp/file')").
-                      with_issue(@issue)
+                      with_issues([@issue, @issue])
     end
 
     it "reports \"mkdir_p('/rails/tmp/my/dir')\" correctly" do
       @runner.should  check("mkdir_p('/rails/tmp/my/dir')").
-                      with_issue(@issue)
+                      with_issues([@issue, @issue])
     end
 
     it "reports \"Tempfile.new\" correctly" do


### PR DESCRIPTION
`Tempfile.new` is secure now.

Related to https://github.com/openSUSE/scanny/issues/14#issuecomment-7612646
Issue #14
