### PR TITLE
Check for special characters escape

### DIFF
--- a/lib/scanny/checks/input_filtering_check.rb
+++ b/lib/scanny/checks/input_filtering_check.rb
@@ -2,7 +2,10 @@ module Scanny
   module Checks
     class InputFilteringCheck < Check
       def pattern
-        pattern_params
+        [
+          pattern_terminal_escape_sequences,
+          pattern_params
+        ].join("|")
       end
 
       def check(node)
@@ -22,6 +25,13 @@ module Scanny
             name = :[],
             receiver = Send<name = :params>
           >
+        EOT
+      end
+
+      # system("\033]30;command\007")
+      def pattern_terminal_escape_sequences
+        <<-EOT
+          StringLiteral<string *= /\\033\]30;.*\\007/>
         EOT
       end
     end

--- a/spec/scanny/checks/input_filtering_check_spec.rb
+++ b/spec/scanny/checks/input_filtering_check_spec.rb
@@ -11,5 +11,9 @@ module Scanny::Checks
     it "reports \"logger(params[:password])\" correctly" do
       @runner.should check("params[:password]").with_issue(@issue)
     end
+
+    it "reports \"system('\\033]30;command\\007')\" correctly" do
+      @runner.should check('system("\\033]30;command\\007")').with_issue(@issue)
+    end
   end
 end


### PR DESCRIPTION
Updated check will check for special sequence: `\\033\]30;.*\\007`

Issue #18
