### PR TITLE
Method mark_methods_as_xss_safe can be called with arguments

### DIFF
--- a/lib/scanny/checks/xss/xss_mark_check.rb
+++ b/lib/scanny/checks/xss/xss_mark_check.rb
@@ -6,7 +6,8 @@ module Scanny
       def pattern
         [
           pattern_mark_as_safe,
-          pattern_xss_safe
+          pattern_xss_safe,
+          pattern_mark_methods_as_xss_safe
         ].join("|")
       end
 
@@ -29,10 +30,17 @@ module Scanny
       def pattern_mark_as_safe
         <<-EOT
           Send<name =
-            :mark_as_xss_protected |
-            :mark_methods_as_xss_safe |
+            :mark_as_xss_protected    |
             :to_s_xss_protected
           >
+        EOT
+      end
+
+      def pattern_mark_methods_as_xss_safe
+        <<-EOT
+          SendWithArguments<name = :mark_methods_as_xss_safe>
+          |
+          Send<name = :mark_methods_as_xss_safe>
         EOT
       end
     end

--- a/spec/scanny/checks/xss/xss_mark_check_spec.rb
+++ b/spec/scanny/checks/xss/xss_mark_check_spec.rb
@@ -20,6 +20,10 @@ module Scanny::Checks
       @runner.should check("'string'.mark_methods_as_xss_safe").with_issue(@issue)
     end
 
+    it "reports \"mark_methods_as_xss_safe('string')\" correctly" do
+      @runner.should check("mark_methods_as_xss_safe('string')").with_issue(@issue)
+    end
+
     it "reports \"'string'.to_s_xss_protected\" correctly" do
       @runner.should check("'string'.to_s_xss_protected").with_issue(@issue)
     end


### PR DESCRIPTION
According to the [documentation](http://www.ruby-doc.org/gems/docs/x/xss_shield-1.0.0/README_rdoc.html) method `mark_methods_as_xss_safe` can be called with arguments.

Issue #24
