### PR TITLE
Remove SUSE specific code from check

### DIFF
--- a/lib/scanny/checks/sql_injection/string_interpolation_with_params_check.rb
+++ b/lib/scanny/checks/sql_injection/string_interpolation_with_params_check.rb
@@ -18,30 +18,6 @@ module Scanny
 
         private
 
-        # "SELECT #{options[:select]} FROM users"
-        def pattern_options_with_select_in_select
-          <<-EOT
-            DynamicString<
-              array = [
-                any*,
-                ToString<
-                  value = SendWithArguments<
-                    arguments = ActualArguments<
-                      array = [
-                        SymbolLiteral<value = :select>
-                      ]
-                    >,
-                    name = :[],
-                    receiver = Send<name = :options>
-                  >
-                >,
-                any*
-              ],
-              string ^= "SELECT"
-            >
-          EOT
-        end
-
         # "SELECT params[:input] FROM users"
         def pattern_params_in_select
           <<-EOT

--- a/spec/scanny/checks/sql_injection/string_interpolation_with_params_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/string_interpolation_with_params_check_spec.rb
@@ -9,11 +9,7 @@ module Scanny::Checks::Sql
       @issue_high = issue(:high, @message, 89)
     end
 
-    it "reports string interpolation with \"options[:select]\" correctly" do
-      @runner.should check('"SELECT #{options[:select]}"').with_issue(@issue_high)
-    end
-
-    it "reports string interpolation with \"options[:select]\" correctly" do
+    it "reports string interpolation with \"params[:input]\" correctly" do
       @runner.should check('"SELECT #{params[:input]}"').with_issue(@issue_high)
     end
   end


### PR DESCRIPTION
`high            CWE-89                  SELECT.*options\[\:select\].*`

Is specific for SUSE.
Issue #7
