### PR TITLE
String interpolation on execute sql

### DIFF
--- a/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
@@ -29,6 +29,19 @@ module Scanny
                   SendWithArguments<
                     name = :[],
                     receiver = Send<name = :params>
+                  >
+                  |
+                  DynamicString<
+                    array = [
+                      any*,
+                      ToString<
+                        value = SendWithArguments<
+                          name = :[],
+                          receiver = Send<name = :params>
+                        >
+                      >,
+                      any*
+                  ]
                   >,
                   any*
                 ]

--- a/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
@@ -59,5 +59,20 @@ module Scanny::Checks::Sql
     it "reports \"paginate\" calls on class with params correctly" do
       @runner.should check('User.paginate params[:password]').with_issue(@issue_high)
     end
+
+    it "reports \"execute\" calls on class with string interpolation correctly" do
+      @runner.should  check('User.execute "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
+
+    it "reports \"find_by_sql\" calls on class with string interpolation correctly" do
+      @runner.should  check('User.find_by_sql "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
+
+    it "reports \"paginate\" calls on class with string interpolation correctly" do
+      @runner.should  check('User.paginate "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
   end
 end


### PR DESCRIPTION
Ruby developers use `User.find_by_sql("SELECT * FROM users WHERE user_id=#{params[:id]}")` instead of `User.find_by_sql(params[:query])`. Thats why scanny should recognize also interpolated string.

Issue #7
