### PR TITLE
Add spawn method to pattern

### DIFF
--- a/lib/scanny/checks/helpers.rb
+++ b/lib/scanny/checks/helpers.rb
@@ -10,7 +10,7 @@ module Scanny
         <<-EOT
             SendWithArguments
             <
-              name = :system | :exec,
+              name = :system | :exec | :spawn,
               arguments = ActualArguments<
                 array = [
                   any*,


### PR DESCRIPTION
Method build_pattern_exec_command should build pattern that can recognize execute system command with spawn method.

Issue #15
