### PR TITLE
Net::HTTP other class update

### DIFF
--- a/lib/scanny/checks/http_request_check.rb
+++ b/lib/scanny/checks/http_request_check.rb
@@ -4,6 +4,7 @@ module Scanny
       def pattern
         [
           pattern_net_http,
+          pattern_net_http_method,
           pattern_net_http_proxy
         ].join("|")
       end
@@ -26,6 +27,23 @@ module Scanny
             receiver = ScopedConstant<
               name = :HTTP,
               parent = ConstantAccess<name = :Net>
+            >,
+            name = :new
+          >
+        EOT
+      end
+
+      def pattern_net_http_method
+        <<-EOT
+          SendWithArguments<
+            receiver = ScopedConstant<
+              name = any,
+              parent = ScopedConstant<
+                name = :HTTP,
+                parent = ConstantAccess<
+                  name = :Net
+                >
+              >
             >,
             name = :new
           >

--- a/spec/scanny/checks/http_request_check_spec.rb
+++ b/spec/scanny/checks/http_request_check_spec.rb
@@ -14,6 +14,21 @@ module Scanny::Checks
                       with_issue(@issue)
     end
 
+    it "reports \"Net::HTTP::Get.new('http://example.com/')\" correctly" do
+      @runner.should  check("Net::HTTP::Get.new('http://example.com/')").
+                      with_issue(@issue)
+    end
+
+    it "reports \"Net::HTTP::Post.new('http://example.com/')\" correctly" do
+      @runner.should  check("Net::HTTP::Post.new('http://example.com/')").
+                      with_issue(@issue)
+    end
+
+    it "reports \"Net::HTTP::Method.new('http://example.com/')\" correctly" do
+      @runner.should  check("Net::HTTP::Method.new('http://example.com/')").
+                      with_issue(@issue)
+    end
+
     it "reports \"Net::HTTP::Proxy('proxy.example.com', 8080)\" correctly" do
       @runner.should  check("Net::HTTP::Proxy('proxy.example.com', 8080)").
                       with_issue(@issue)


### PR DESCRIPTION
Scanny now recognize

``` ruby
Net::HTTP::Post.new
Net::HTTP::Get.new
Net::HTTP::OtherMethod.new
# ...
```

Issue #17
