### PR TITLE
Find methods on objects

### DIFF
--- a/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
@@ -46,8 +46,7 @@ module Scanny
                   any*
                 ]
               >,
-              name = :execute | :find_by_sql | :paginate,
-              receiver = ConstantAccess
+              name = :execute | :find_by_sql | :paginate
             >
           EOT
         end

--- a/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
+++ b/spec/scanny/checks/sql_injection/find_method_with_params_check_spec.rb
@@ -74,5 +74,20 @@ module Scanny::Checks::Sql
       @runner.should  check('User.paginate "#{params[:password]}"').
                       with_issue(@issue_high)
     end
+
+    it "reports \"execute\" calls on object with string interpolation correctly" do
+      @runner.should  check('@object.execute "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
+
+    it "reports \"find_by_sql\" calls on object with string interpolation correctly" do
+      @runner.should  check('@object.find_by_sql "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
+
+    it "reports \"paginate\" calls on object with string interpolation correctly" do
+      @runner.should  check('@object.paginate "#{params[:password]}"').
+                      with_issue(@issue_high)
+    end
   end
 end


### PR DESCRIPTION
Methods `execute`, `find_by_sql`, `paginate` can be called with object

``` ruby
@object.execute("SQL")
```

Scanny should recognize call of this type.

Related to: https://github.com/openSUSE/scanny/issues/7#issuecomment-7675531
Issue #7
