### PR TITLE
Use any+ instead of any{1,}

### DIFF
--- a/lib/scanny/checks/denial_of_service_check.rb
+++ b/lib/scanny/checks/denial_of_service_check.rb
@@ -22,7 +22,7 @@ module Scanny
           SendWithArguments<
             arguments = ActualArguments<
               array = [
-                any{1,},
+                any+,
                 HashLiteral<
                   array = [
                     any{even},

--- a/lib/scanny/checks/sql_injection/find_method_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_check.rb
@@ -59,7 +59,7 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any{1,},
+                  any+,
                   HashLiteral<
                     array = [
                       any{even},

--- a/lib/scanny/checks/sql_injection/find_method_with_dynamic_string_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_dynamic_string_check.rb
@@ -22,7 +22,7 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any{1,},
+                  any+,
                   HashLiteral<
                     array = [
                       any{even},

--- a/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
+++ b/lib/scanny/checks/sql_injection/find_method_with_params_check.rb
@@ -58,7 +58,7 @@ module Scanny
             SendWithArguments<
               arguments = ActualArguments<
                 array = [
-                  any{1,},
+                  any+,
                   HashLiteral<
                     array = [
                       any{even},


### PR DESCRIPTION
Because machete support any+ scanny should use cleaner notation
