### PR TITLE
SimpleReporter spec should not write to $stdout

### DIFF
--- a/spec/scanny/reporters/simple_reporter_spec.rb
+++ b/spec/scanny/reporters/simple_reporter_spec.rb
@@ -10,6 +10,7 @@ module Scanny
             nodes_inspected  = 10
 
             reporter = SimpleReporter.new
+            reporter.stub(:puts)
             reporter.file             = 'foo.rb'
             reporter.checks_performed = checks_performed
             reporter.nodes_inspected  = nodes_inspected
@@ -26,6 +27,7 @@ module Scanny
             nodes_inspected  = 10
 
             reporter = SimpleReporter.new
+            reporter.stub(:puts)
             reporter.file             = 'foo.rb'
             reporter.checks_performed = checks_performed
             reporter.nodes_inspected  = nodes_inspected


### PR DESCRIPTION
During testing SimpleReporter use `puts` method. Because SimpleReporter can't find this method in instance methods they use `puts` from `Kernel`. It will send report to `$stdout`. Simple stub should keep clean spec output.
